### PR TITLE
Downgrade dependency on intl to 0.19.0 for compatibility with flutter_localizations

### DIFF
--- a/bundle/example/pubspec.lock
+++ b/bundle/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   device_vendor_info:
     dependency: "direct main"
     description:
@@ -145,10 +145,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -227,5 +227,5 @@ packages:
     source: hosted
     version: "1.1.5"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/interface/pubspec.yaml
+++ b/interface/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   meta: ^1.15.0
   json_annotation: ^4.9.0
-  intl: '>=0.20.0 <1.0.0'
+  intl: '>=0.19.0 <1.0.0'
   async: ^2.11.0
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Applications depending on flutter_localizations (for example because they use fluent_ui) are unable to install the latest device_vendor_info, because the Flutter SDK pins flutter_localizations to 0.19.0 (https://github.com/dart-lang/sdk/blob/main/docs/Flutter-Pinned-Packages.md#what-are-flutter-pinned-packages) This downgrades the dependency on intl to 0.19.0, so it matches the version pinned by the SDK itself.