### PR TITLE
Fix error in Windows' guardAssign

### DIFF
--- a/windows/lib/src/loader.dart
+++ b/windows/lib/src/loader.dart
@@ -36,7 +36,7 @@ final class WindowsDeviceVendorInfoLoader
 
   static Future<void> _guardAssign(FutureOr<void> Function() assigner) async {
     try {
-      assigner();
+      await assigner();
     } on InvalidDictionaryKeyError {
       // Do nothing
     }


### PR DESCRIPTION
For reasons unknown to me, on some systems, the code from aebfa28e01cb5f742c6be20deeb2db869bbcc1c9 seems to return an empty string for all properties. Despite my intuition that this shouldn't matter, an additional 'await' fetches the values reliably.

Does this make sense? It doesn't to me, but it works...

Sorry for the troubles.